### PR TITLE
Gradle tools upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
          *  - Stable: https://developer.android.com/studio/releases/gradle-plugin.html
          *  - Alpha: http://tools.android.com/tech-docs/new-build-system
          */
-        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
 
         // Google Services Plugin - Required for Firebase and related Google services
         // https://developers.google.com/android/guides/google-services-plugin


### PR DESCRIPTION
Upgraded to new version to fix CI.

* What went wrong:
A problem occurred evaluating project ':api-lib'.
> Failed to apply plugin [id 'com.android.library']
   > Could not create plugin of type 'LibraryPlugin'.
      > The android gradle plugin version 2.3.0-beta1 is too old, please update to the latest version.